### PR TITLE
Fix bug #2009: Not using downloaded repomd.xml because it is older than what we have

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -132,7 +132,8 @@ if distro == "RedHat" or distro == "CentOS":
         else:
             qemu_pkg = 'qemu-kvm'
         # name: install kvm related packages on RedHat based OS from user defined repo
-        command = ("pkg_list=`rpm -q openssh-clients %s bridge-utils wget libvirt-python libvirt nfs-utils sed "
+        command = ("yum clean metadata && "
+                   "pkg_list=`rpm -q openssh-clients %s bridge-utils wget libvirt-python libvirt nfs-utils sed "
                    "vconfig libvirt-client net-tools iscsi-initiator-utils lighttpd dnsmasq iproute sshpass iputils "
                    "libguestfs-winsupport libguestfs-tools pv "
                    "rsync nmap | grep \"not installed\" | awk '{ print $2 }'` && for pkg in $pkg_list; do yum "
@@ -145,7 +146,8 @@ if distro == "RedHat" or distro == "CentOS":
         run_remote_command(command, host_post_info)
         if distro_version >= 7:
             # name: RHEL7 specific packages from user defined repos
-            command = ("pkg_list=`rpm -q collectd-virt | grep \"not installed\" | awk '{ print $2 }'` && for pkg "
+            command = ("yum clean metadata && "
+                       "pkg_list=`rpm -q collectd-virt | grep \"not installed\" | awk '{ print $2 }'` && for pkg "
                        "in $pkg_list; do yum --disablerepo=* --enablerepo=%s "
                        "--nogpgcheck install -y $pkg; done;") % zstack_repo
             host_post_info.post_label = "ansible.shell.install.pkg"


### PR DESCRIPTION
添加物理机时报错：
```
stderr: ERROR: [ HOST: 192.168.99.63 ] ERROR: run shell command: pkg_list=`rpm -q openssh-clients
 qemu-kvm-ev-2.3.0 bridge-utils wget libvirt-python libvirt nfs-utils sed vconfig libvirt-client net-tools 
iscsi-initiator-utils lighttpd dnsmasq iproute sshpass iputils libguestfs-winsupport libguestfs-tools rsync
 nmap | grep "not installed" | awk '{ print $2 }'` && for pkg in $pkg_list; do yum --disablerepo=* --
enablerepo="zstack-mn,qemu-kvm-ev-mn" install -y $pkg; done; failed!error: Not using downloaded 
repomd.xml because it is older than what we have:
```

解决方法：在执行`yum install`之前，通过`yum clean metadata`进行清理。