### PR TITLE
Refix bug #2009: yum clean metadata will fail when no repo is enabled

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -132,12 +132,12 @@ if distro == "RedHat" or distro == "CentOS":
         else:
             qemu_pkg = 'qemu-kvm'
         # name: install kvm related packages on RedHat based OS from user defined repo
-        command = ("yum clean metadata && "
+        command = ("yum --enablerepo=%s clean metadata && "
                    "pkg_list=`rpm -q openssh-clients %s bridge-utils wget libvirt-python libvirt nfs-utils sed "
                    "vconfig libvirt-client net-tools iscsi-initiator-utils lighttpd dnsmasq iproute sshpass iputils "
                    "libguestfs-winsupport libguestfs-tools pv "
                    "rsync nmap | grep \"not installed\" | awk '{ print $2 }'` && for pkg in $pkg_list; do yum "
-                   "--disablerepo=* --enablerepo=%s install -y $pkg; done;") % (qemu_pkg, zstack_repo)
+                   "--disablerepo=* --enablerepo=%s install -y $pkg; done;") % (zstack_repo, qemu_pkg, zstack_repo)
         host_post_info.post_label = "ansible.shell.install.pkg"
         host_post_info.post_label_param = "openssh-clients,%s,bridge-utils,wget,sed," \
                                           "libvirt-python,libvirt,nfs-utils,vconfig,libvirt-client,net-tools," \
@@ -146,10 +146,10 @@ if distro == "RedHat" or distro == "CentOS":
         run_remote_command(command, host_post_info)
         if distro_version >= 7:
             # name: RHEL7 specific packages from user defined repos
-            command = ("yum clean metadata && "
+            command = ("yum --enablerepo=%s clean metadata && "
                        "pkg_list=`rpm -q collectd-virt | grep \"not installed\" | awk '{ print $2 }'` && for pkg "
                        "in $pkg_list; do yum --disablerepo=* --enablerepo=%s "
-                       "--nogpgcheck install -y $pkg; done;") % zstack_repo
+                       "--nogpgcheck install -y $pkg; done;") % (zstack_repo, zstack_repo)
             host_post_info.post_label = "ansible.shell.install.pkg"
             host_post_info.post_label_param = "collectd-virt"
             run_remote_command(command, host_post_info)


### PR DESCRIPTION
当MN与HOST是不同的两台机器时，HOST上的Yum repo都是`enabled=0`的。
此时执行`yum clean metadata`会失败，从而导致`&&`之后的命令不会被执行。

而在离线安装的All-In-One模式下，HOST上起码有`zstack-local`是`enable=1`的，
不会导致`yum clean metadata`命令失败。

这里将clean的范围限制在了`zstack-mn`和`qemu-kvm-ev-mn`两个repo上，以保证clean不会失败。
如果这两个repo不存在，那么`&&`之后的`yum install`肯定也会失败。