### PR TITLE
Create a daemon clean stale vnc iptables

### DIFF
--- a/kvmagent/kvmagent/kdaemon.py
+++ b/kvmagent/kvmagent/kdaemon.py
@@ -35,15 +35,19 @@ def main():
 
         cmd = sys.argv[1]
         agentdaemon = kvmagent.KvmDaemon(pidfile)
+        iptablesDaemon = kvmagent.iptablesDaemon()
         if cmd == 'start':
             logger.debug('zstack-kvmagent starts')
             agentdaemon.start()
+            iptablesDaemon.start()
         elif cmd == 'stop':
             logger.debug('zstack-kvmagent stops')
             agentdaemon.stop()
+            iptablesDaemon.stop()
         elif cmd == 'restart':
             logger.debug('zstack-kvmagent restarts')
             agentdaemon.restart()
+            iptablesDaemon.restart()
         sys.exit(0)    
     except Exception:
         logger.warning(linux.get_exception_stacktrace())

--- a/kvmagent/kvmagent/kvmagent.py
+++ b/kvmagent/kvmagent/kvmagent.py
@@ -2,6 +2,7 @@
 
 @author: frank
 '''
+from kvmagent.plugins import vm_plugin
 from zstacklib.utils import plugin
 from zstacklib.utils import http
 from zstacklib.utils import log
@@ -13,6 +14,7 @@ import traceback
 import pprint
 import functools
 import string
+import time
 
 from zstacklib.utils import shell
 
@@ -141,6 +143,14 @@ class KvmDaemon(daemon.Daemon):
     def run(self):
         self.agent = new_rest_service()
         self.agent.start(in_thread=False)
+
+class iptablesDaemon(daemon.Daemon):
+    def __init__(self, pidfile, config={}):
+        super(iptablesDaemon, self).__init__(pidfile)
+
+    def run(self):
+        vm_plugin.cleanup_stale_vnc_iptable_chains()
+        time.sleep(600)
 
 SEND_COMMAND_URL = 'SEND_COMMAND_URL'
 HOST_UUID = 'HOST_UUID'

--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -3284,15 +3284,15 @@ class VmPlugin(kvmagent.KvmAgent):
                     # we have to ask mgmt server to reboot the agent
                     url = self.config.get(kvmagent.SEND_COMMAND_URL)
                     if not url:
-                        logger.warn('cannot find SEND_COMMAND_URL, unable to ask the mgmt server to reconnect us')
+                        logger.warn('cannot find SEND_COMMAND_URL, unable to ask the management server to reconnect us')
                         os._exit(1)
 
                     host_uuid = self.config.get(kvmagent.HOST_UUID)
                     if not host_uuid:
-                        logger.warn('cannot find HOST_UUID, unable to ask the mgmt server to reconnect us')
+                        logger.warn('cannot find HOST_UUID, unable to ask the management server to reconnect us')
                         os._exit(1)
 
-                    logger.warn("libvirt has been rebooted or stopped, ask the mgmt server to reconnt us")
+                    logger.warn("libvirt has been rebooted or stopped, ask the management server to reconnect us")
                     cmd = ReconnectMeCmd()
                     cmd.hostUuid = host_uuid
                     cmd.reason = "libvirt rebooted or stopped"
@@ -3416,7 +3416,7 @@ class VmPlugin(kvmagent.KvmAgent):
             if vm_uuid.startswith("guestfs-"):
                 logger.debug("[set_vnc_port_iptable]ignore the temp vm[%s] while using guestfish" % vm_uuid)
                 return
-
+            
             domain_xml = dom.XMLDesc(0)
             domain_xmlobject = xmlobject.loads(domain_xml)
 
@@ -3459,6 +3459,7 @@ class VmPlugin(kvmagent.KvmAgent):
         except:
             content = traceback.format_exc()
             logger.warn(content)
+
 
     def register_libvirt_event(self):
         LibvirtAutoReconnect.add_libvirt_callback(libvirt.VIR_DOMAIN_EVENT_ID_LIFECYCLE, self._vm_lifecycle_event)


### PR DESCRIPTION
[Problem] 
kvmagent set_vnc_iptables_rule hook might meet libvirt error

[Solution]
create a daemon to clean stale vnc iptables 10 minutes a round

for https://github.com/zstackio/issues/issues/1962