### PR TITLE
Fix Bug #2298: No space left on device in MN

### DIFF
--- a/zstackctl/zstack-ctl
+++ b/zstackctl/zstack-ctl
@@ -4,5 +4,24 @@ if [ ! -d $VIRTUAL_ENV ]; then
     echo "Need to install zstackctl before using it"
     exit 1
 fi
+
+# check disk space
+all_full=true
+paths=('/tmp', '/var/tmp', '/usr/tmp', '/root')
+for path in ${paths[@]}; do
+  percent="100%"
+  if [ -d $path ]; then
+      percent=`df -H $path | sed '1d' | awk '{print $(NF-1)}'`
+  fi
+  if [ x"$percent" != x"100%" ]; then
+      all_full=false
+      break
+  fi
+done
+if [ $all_full == true ]; then
+  echo -e "\033[31m There is not enough disk space available for zstack-ctl! \033[0m"
+  exit 1
+fi
+
 . $VIRTUAL_ENV/bin/activate
 python -c "from zstackctl import ctl; ctl.main()" $@


### PR DESCRIPTION
根据磁盘空间占满后`zstack-ctl`的出错信息，判断出错误原因在于间接引入的`ansible/callbacks.py`需要调用`_get_default_tempdir()`，该函数在测试完` ['/tmp', '/var/tmp', '/usr/tmp', '/root']`后仍然无法找到可用于创建临时文件的目录，返回错误。

由于`ansible`对于`zstack-ctl`来讲属于依赖，无法直接对其进行修改。通过在`zstackctl/zstack-ctl`脚本中加判断解决此问题：执行任何`zstack-ctl`命令时先检查是否有空闲空间，没有则打印错误信息。

`zstack-cli`命令不受磁盘空间影响。