### PR TITLE
Fix Bug #2499: ZSTACK-ENTERPRISE is too long for FIGlet

### DIFF
--- a/zstackbuild/scripts/gen_installation_title.sh
+++ b/zstackbuild/scripts/gen_installation_title.sh
@@ -4,7 +4,9 @@ output_file=$3
 
 which figlet
 if [ $? -eq 0 ]; then
-    figlet -w 80 $product |tee -a $output_file
+    # handle long product name
+    # only works for zstack-enterprise etc.
+    figlet -w 80 `echo $product | sed 's/-/\n/g'` |tee -a $output_file
     figlet -w 80 v $version |tee -a $output_file
     figlet -w 80 INSTALLATION |tee -a $output_file
 fi


### PR DESCRIPTION
https://github.com/zstackio/issues/issues/2499

`gen_installation_title.sh`中，FIGlet的生成宽度被限制在80列。
`ZSTACK-ENTERPRISE`在变换之后会超过80，从而被强制换行，影响显示效果。
解决方法是将短横替换为换行，从而让`ZSTACK`和`ENTERPRISE`各占一行。

但该方法无法处理非短横连接的长命名；
而且由于字符不等宽，没有将长度作为判断依据，只做了简单地替换。