### PR TITLE
fix a logic in VncPortIptableRule

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -259,7 +259,7 @@ class VncPortIptableRule(object):
             raise kvmagent.KvmError(err)
 
         # get ipv4 subnet
-        current_ip_with_netmask = shell.call('ip -o -f inet addr show | awk \'/scope global/ {print $4}\' | fgrep %s' % current_ip).strip()
+        current_ip_with_netmask = shell.call('ip -o -f inet addr show | awk \'/scope global/ {print $4}\' | fgrep %s' % current_ip).strip().split('\n', 1)[0]
         if "" == shell.call("echo %s | grep -o \'[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}\'" % current_ip_with_netmask):
             err = 'cannot get host ip with netmask for %s' % self.host_ip
             logger.warn(err)


### PR DESCRIPTION
after bridge created and interface has been added to it, may get two same lines of ip.ip.ip.ip/netmask, that would cause failed to get right parameter.
the fix is just to get first line.