### PR TITLE
Fix Bug #2505: Update ISO version check strategy due to PRODUCT_NAME updates

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -1971,7 +1971,7 @@ set_tomcat_config() {
     sed -i 's/maxThreads=".*"/maxThreads="'"$new_max_thread_num"'"/' $tomcat_config_path/server.xml
 }
 
-check_iso_version() {
+check_repo_version() {
 	[ ! -f ".repo_version" ] && return 1
 	[ ! -f "/opt/zstack-dvd/.repo_version" ] && return 1
 	diff .repo_version /opt/zstack-dvd/.repo_version >/dev/null 2>&1
@@ -2266,20 +2266,14 @@ sleep 0.3
 echo ""
 fi
 
-# check iso version
-# - If PRODUCT_NAME is zstack, then do not check iso version
-# - If PRODUCT_NAME is mevoco, then check iso version, and ISO name is ZStack-Enterprise-...
-# - If PRODUCT_NAME is something else, then check iso version, and ISO name is ${PRODUCT_NAME}-Enterprise-...
-if [ x'zstack' != x"$PRODUCT_NAME" ]; then
-	if [ x'mevoco' = x"$PRODUCT_NAME" ]; then
-		ISO_NAME="ZStack"
-	else
-		ISO_NAME=${PRODUCT_NAME}
-	fi
-	check_iso_version
+# CHECK_REPO_VERSION
+if [ x"${CHECK_REPO_VERSION}" == x"True" ]; then
+	check_repo_version
 	if [ $? -ne 0 ]; then
+		ISO_NAME=${PRODUCT_NAME^}
+		[ x"${PRODUCT_NAME^^}" == x"ZSTACK-ENTERPRISE" ] && ISO_NAME="ZStack-Enterprise"
 		BIN_VERSION=`echo $PRODUCT_VERSION | awk -F '.' '{print $1"."$2"."$3}'`
-		fail2 "The Operating System version is not suitable for ${PRODUCT_NAME} installation.\nPlease download and upgrade your Operating System to ${ISO_NAME}-Enterprise-x86-64-DVD-${BIN_VERSION}.iso"
+		fail2 "The Operating System version is not suitable for ${PRODUCT_NAME} installation.\nPlease download and upgrade your Operating System to ${ISO_NAME}-x86-64-DVD-${BIN_VERSION}.iso"
 	fi
 fi
 

--- a/zstackbuild/projects/zstack-buildallinone.xml
+++ b/zstackbuild/projects/zstack-buildallinone.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="zstack all in one package builder" basedir="../">
     <property name="target.license.file" location="${allinone.dir}/zstack-license" />
-    <property name="zstack.iso.version" location="${zstack.distro.source}/mkiso/.repo_version" />
+    <property name="zstack.repo.version" location="${zstack.distro.source}/mkiso/.repo_version" />
+    <condition property="check.repo.version" value="True" else="False">
+        <and>
+            <isset property="build_war_flag"/>
+        </and>
+    </condition>
 
     <target name="all-in-one-package" >
         <copy file="${zstack.install}" todir="${build.dir}" />
@@ -16,16 +21,16 @@
         <copy file="${license.file}" tofile="${target.license.file}" />
     </target>
 
-    <target name="check-iso-version-exists">
-        <available file="${zstack.iso.version}"  property="iso.version.exists"/>
+    <target name="check-repo-version-exists">
+        <available file="${zstack.repo.version}"  property="repo.version.exists"/>
     </target>
 
-    <target name="copy-iso-version" depends="check-iso-version-exists" if="iso.version.exists">
+    <target name="copy-repo-version" depends="check-repo-version-exists" if="repo.version.exists">
         <echo message="copy .repo_version to ${allinone.bin.dir}" />
-        <copy file="${zstack.iso.version}" todir="${allinone.bin.dir}" />
+        <copy file="${zstack.repo.version}" todir="${allinone.bin.dir}" />
     </target>
 
-    <target name="build-centos-offline" depends="copy-license-file, check-iso-version-exists">
+    <target name="build-centos-offline" depends="copy-license-file, check-repo-version-exists">
         <copy file="${war.file}" todir="${allinone.dir}" />
         <echo message="copy apache-tomcat to ${allinone.file}" />
         <copy file="${apachetomcat.pkg}" todir="${allinone.dir}" />
@@ -39,6 +44,7 @@
             <arg value="${offline.bin.gen.setup.script}" />
             <arg value="${product.name}" />
             <arg value="${product.version}" />
+            <arg value="${check.repo.version}" />
             <arg value="${offline.bin.setup.script}" />
         </exec>
 
@@ -54,12 +60,12 @@
                 <and>
                     <isset property="build_war_flag" />
                     <not>
-                        <isset property="iso.version.exists" />
+                        <isset property="repo.version.exists" />
                     </not>
                 </and>
             </condition>
         </fail>
-        <antcall target="copy-iso-version" />
+        <antcall target="copy-repo-version" />
 
         <tar destfile="${allinone.offline.file}" basedir="${allinone.bin.dir}" />
         <exec executable="bash" dir="${build.dir}" failonerror="true">

--- a/zstackbuild/scripts/gen_setup.sh
+++ b/zstackbuild/scripts/gen_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cat >$3 <<EOF
+cat >$4 <<EOF
 #!/bin/bash
 line=\`wc -l \$0|awk '{print \$1}'\`
 line=\`expr \$line - 11\`
@@ -8,7 +8,7 @@ tmpdir=\`mktemp\`
 mkdir -p \$tmpdir
 tail -n \$line \$0 |tar x -C \$tmpdir
 cd \$tmpdir
-PRODUCT_NAME=$1 PRODUCT_VERSION=$2 bash ./install.sh -a -f zstack*.tgz \$*
+PRODUCT_NAME=$1 PRODUCT_VERSION=$2 CHECK_REPO_VERSION=$3 bash ./install.sh -a -f zstack*.tgz \$*
 ret=\$?
 rm -rf \$tmpdir
 exit \$ret


### PR DESCRIPTION
**社区版ZStack**（包括ZStack-Enterprise之外的合作版本）仅支持离线安装，因此在安装前需要检查当前环境是否满足离线安装条件。
凡是通过云轴官方发布的ISO安装的系统环境，其`/opt/zstack-dvd/.repo_version`中都会记录一个类似于`070114`的值，用于表征离线源的版本。安装包在安装期间会将该值与自身记录的值进行比对，不一致则报错。

1.10之前，`PRODUCT_NAME`分别为`zstack`和`mevoco`，安装脚本以此作为判断是否需要版本检查的依据。
1.10开始，`PRODUCT NAME`发生了改变，且未来还可能有很多合作版本，比如`aliyun-zstack`等。因此，以`PRODUCT_NAME`为依据是不合适的。

离线源版本检查的原则是：**仅在安装企业版安装包时才执行离线源版本检查**，因此判定依据应该是**是否为企业版**。
在打包企业版安装包时，会向打包脚本传递`-Dbuild_war_flag=premium`的参数。通过判断该参数是否存在，决定`CHECK_REPO_VERSION`的值，并将`CHECK_REPO_VERSION`的值传递给安装脚本`installation/install.sh`，安装脚本就可以据此判定是否进行版本检查了。