### PR TITLE
Fix Bug #2522

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -2140,7 +2140,7 @@ do
         o ) YUM_ONLINE_REPO='' && ZSTACK_OFFLINE_INSTALL='y' && 
 		[ "zstack.org" = "$WEBSITE" ] && WEBSITE='localhost';;
         # -O: use yum online repo
-        O ) if [ x'zstack' = x"$PRODUCT_NAME" ]; then
+        O ) if [ x"${CHECK_REPO_VERSION}" != x"True" ]; then
 		YUM_ONLINE_REPO='y'
 		ZSTACK_OFFLINE_INSTALL=''
 		else
@@ -2151,7 +2151,7 @@ do
         q ) QUIET_INSTALLATION='y';;
         r ) ZSTACK_INSTALL_ROOT=$OPTARG;;
         # -R: use yum third party repo
-        R ) if [ x'zstack' = x"$PRODUCT_NAME" ]; then
+        R ) if [ x"${CHECK_REPO_VERSION}" != x"True" ]; then
 		ZSTACK_PKG_MIRROR=$OPTARG
 		YUM_ONLINE_REPO='y'
 		ZSTACK_OFFLINE_INSTALL=''


### PR DESCRIPTION
-O and -R should not use PRODUCT_NAME=zstack any more

-R参数涉及到社区版和企业版的判定，之前使用`PRODUCT_NAME=zstack`来判定社区版，现改为使用`CHECK_REPO_VERSION != True`来判定社区版。