### PR TITLE
Fix Bug #2565

### DIFF
--- a/zstacklib/ansible/zstacklib.py
+++ b/zstacklib/ansible/zstacklib.py
@@ -268,10 +268,15 @@ def handle_ansible_failed(description, result, host_post_info):
     cost_time = (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6.0 * 1000
     msg.label = host_post_info.post_label
     msg.parameters = host_post_info.post_label_param
+    if 'stdout' in result['contacted'][host]:
+        msg.details = "[ HOST: %s ] " % host_post_info.host + description + "stdout: " + result['contacted'][host]['stdout']
+    else:
+        msg.details = "[ HOST: %s ] " % host_post_info.host + description
+
     if 'stderr' in result['contacted'][host]:
-        msg.details = "[ HOST: %s ] " % host_post_info.host + description + "error: " + result['contacted'][host]['stderr']
+        msg.details += " error: " + result['contacted'][host]['stderr']
     elif 'msg' in result['contacted'][host]:
-        msg.details = "[ HOST: %s ] " % host_post_info.host + description + "error: " + result['contacted'][host]['msg']
+        msg.details += " error: " + result['contacted'][host]['msg']
 
     msg.level = "ERROR"
     post_msg(msg, post_url)


### PR DESCRIPTION
[Tip message is not clear when adding/reconnecting the HOST.](https://github.com/zstackio/issues/issues/2565)

在Utility/zstacklib中，有`run_remote_command`函数，该函数用于通过Ansible远程执行命令，并返回执行结果和输出。当执行出错时，会调用`handle_ansible_failed`，该函数利用`result['stderr']`构造`msg.detail`。

多数情况下，这样的`msg.detail`是足够的。但在执行特定命令，比如`yum --disablerepo=* --enablerepo=zstack-mn, qemu-kvm-ev pv`时，`msg.detail`仅包含`Nothing to do`，而真正的错误信息保存于`result['stdout']`中被丢弃了。

因此修改`handle_ansible_failed`函数`msg.detail`的构造方式，将`result['stdout']`和`result['stderr]`合并在一起，返回给用户。

修改之后的报错信息：
```
\nNo package libguestfs-tools available.\nLoaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\nNo package pv available. error: Error: Nothing to do\nError: Nothing to do\n\nstdout: "},
```