### PR TITLE
add hostname check before start mn

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -1408,14 +1408,12 @@ class StartCmd(Command):
             warn("Can't get system memory size from /proc/meminfo")
 
     def check_hostname(self):
-        o = shell('hostnamectl')
-        list = o.split('\n')
-        for attr in list:
-            if 'Static hostname' in attr and ('.' in attr or ',' in attr):
-                hostname = attr.replace('Static hostname:', '').lstrip()
-                error("Hostname cannot contain ','or '.', current hostname is '%s'.\n"
-                      "Please use following command to modify hostname\n"
-                      "hostnamectl set-hostname $hostname" % hostname)
+        hn = shell('hostname').strip()
+        if '.' in hn:
+            error("The hostname cannot contain '.', current hostname is '%s'.\n"
+                  "Please use the following commands to modify hostname and reset rabbitmq:\n"
+                  " # hostnamectl set-hostname $NEW_HOSTNAME\n"
+                  " # zstack-ctl reset_rabbitmq" % hn)
 
     def run(self, args):
         self.check_cpu_mem()


### PR DESCRIPTION
使用`hostname`获取当前系统的HOSTNAME，并加以判断。
若发现HOSTNAME不合法，则提示使用`hostnamectl set-hostname`来修改HOSTNAME；
使用`zstack-ctl reset_rabbitmq`重置RabbitMQ。