### PR TITLE
Fix bug #2671: MN needs not install libvirt

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -842,12 +842,9 @@ is_install_general_libs_rh(){
             java-1.8.0-openjdk \
             bridge-utils \
             wget \
-            libvirt-python \
-            libvirt \
             nfs-utils \
             rpcbind \
             vconfig \
-            libvirt-client \
             python-devel \
             gcc \
             autoconf \


### PR DESCRIPTION
根据松涛和华星的建议，管理节点默认不安装libvirt。
当管理节点将自身添加为物理机时才会安装libvirt。

zstack-distro库会做相应的修改，保证用户选择安装管理节点或者选择专家模式不会自动安装libvirt。