### PR TITLE
libvirtd support xml namespace since 0.9.10, no need to limit to 1.3.3.

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -355,7 +355,7 @@ def get_libvirt_version():
 LIBVIRT_VERSION = get_libvirt_version()
 
 def is_namespace_used():
-    return compare_version(LIBVIRT_VERSION, '1.3.3') >= 0
+    return compare_version(LIBVIRT_VERSION, '0.9.10') >= 0
 
 class LibvirtEventManager(object):
     EVENT_DEFINED = "Defined"


### PR DESCRIPTION
otherwise with lower versions, it will affect harden_console & _set_vnc_port_iptable_rule
in this file, causing no vnc rules added for a newly created vm