### PR TITLE
[fix Bug2789]add the usage of -k

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -2059,7 +2059,7 @@ Options:
         If multiple IP addresses share same net device, e.g. em1, em1:1, em1:2.
         The network interface should be the exact name, like -I em1:1
 
-  -k    keep previous zstack DB if it exists. If using -k with -u, will not upgrade database not start management node.
+  -k    keep previous zstack DB if it exists. If using -k with -u, will not upgrade database or start management node. Do not use this option unless you really know what is means.
 
   -l    only just install ${PRODUCT_NAME} dependent libraries
 


### PR DESCRIPTION
when upgrate ZStack and keep the version of database,ZStack cannot work and the ui cannot throw the right error.So,add the description in --help
https://github.com/zstackio/issues/issues/2789