### PR TITLE
add timeout when mount nfs

### DIFF
--- a/zstacklib/zstacklib/utils/linux.py
+++ b/zstacklib/zstacklib/utils/linux.py
@@ -188,9 +188,14 @@ def mount(url, path, options=None):
         os.makedirs(path, 0775)
 
     if options:
-        shell.call('mount -o %s %s %s' % (options, url, path))
+        o = shell.ShellCmd('timeout 180 mount -o %s %s %s' % (options, url, path))
     else:
-        shell.call("mount %s %s" % (url, path))
+        o = shell.ShellCmd("timeout 180 mount %s %s" % (url, path))
+    o(False)
+    if o.return_code == 124:
+        raise Exception('unable to mount the nfs primary storage[url:%s] in 180s, timed out' % url)
+    elif o.return_code != 0:
+        o.raise_error()
 
 def umount(path, is_exception=True):
     cmd = shell.ShellCmd('umount -f -l %s' % path)


### PR DESCRIPTION
there are four places I modify:

1. if update url fail, APIupdate will fail,
   agent will filter exception except "No such file" and "time out" when mount nfs
3. when attach nfs, modify sync mount to async mount
3. move checkurl and checkVm to API validate when updateUrl 
4. add timeout when agent mount nfs, timeout is 180s

BAT pass

 for https://github.com/zstackio/issues/issues/2756