### PR TITLE
Refix bug #2814: Add upgrade wiki link in error message

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -2301,10 +2301,11 @@ if [ x"${CHECK_REPO_VERSION}" == x"True" ]; then
 		if [ x"${PRODUCT_NAME^^}" == x"ZSTACK-COMMUNITY" ]; then
 			ISO_NAME="ZStack-Community-x86-64-DVD-${BIN_VERSION}.iso "
 			UPGRADE_WIKI="http://zstack.io/community/tutorials/ISOupgrade/"
-			ISO_DOWNLOAD_LINK="http://zstack.io/community/downloads/"
+			ISO_DOWNLOAD_LINK="http://www.zstack.io/community/downloads/"
 			fail2 "The current local repo is not suitable for ${PRODUCT_NAME} installation.\n" \
 				"Please download ${ISO_NAME} from ${ISO_DOWNLOAD_LINK} and run:\n" \
-				"# zstack-upgrade ${ISO_NAME}\n" \
+				"# wget http://cdn.zstack.io/product_downloads/scripts/zstack-upgrade\n" \
+				"# sh zstack-upgrade ${ISO_NAME}\n" \
 				"For more information, see ${UPGRADE_WIKI}"
 		elif [ x"${PRODUCT_NAME^^}" == x"ZSTACK-ENTERPRISE" ]; then
 			ISO_NAME="ZStack-Enterprise-x86-64-DVD-${BIN_VERSION}.iso"
@@ -2312,7 +2313,8 @@ if [ x"${CHECK_REPO_VERSION}" == x"True" ]; then
 			ISO_DOWNLOAD_LINK="http://www.zstack.io/product_downloads/"
 			fail2 "The current local repo is not suitable for ${PRODUCT_NAME} installation.\n" \
 				"Please download ${ISO_NAME} from ${ISO_DOWNLOAD_LINK} and run:\n" \
-				"# zstack-upgrade ${ISO_NAME}\n" \
+				"# wget http://cdn.zstack.io/product_downloads/scripts/zstack-upgrade\n" \
+				"# sh zstack-upgrade ${ISO_NAME}\n" \
 				"For more information, see ${UPGRADE_WIKI}"
 		else
 			fail2 "The current local repo is not suitable for ${PRODUCT_NAME} installation.\n" \


### PR DESCRIPTION
企业版提示内容：
```
Reason: The Operating System version is not suitable for zstack-enterprise installation.
Please download ZStack-Enterprise-x86-64-DVD-1.11.0.iso from http://www.zstack.io/product_downloads/ and run:
# wget http://cdn.zstack.io/product_downloads/scripts/zstack-upgrade
# sh zstack-upgrade PATH_TO_ZSTACK_ISO
For more information, see http://www.zstack.io/support/tutorials/upgrade/
```

社区版提示内容：
```
Reason: The Operating System version is not suitable for zstack-community installation.
Please download ZStack-Community-x86-64-DVD-1.11.0.iso from http://www.zstack.io/community/downloads/ and run:
# wget http://cdn.zstack.io/product_downloads/scripts/zstack-upgrade
# sh zstack-upgrade PATH_TO_ZSTACK_ISO
For more information, see http://www.zstack.io/community/tutorials/ISOupgrade/
```

第三方版本提示内容：
```
The current local repo is not suitable for ${PRODUCT_NAME} installation.
Please download proper ISO and upgrade the local repo first.
```