### PR TITLE
Fix bug #2831: Wrong timestamp for upgrade backup folder

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -5521,7 +5521,7 @@ class UpgradeManagementNodeCmd(Command):
         if need_download:
             error_if_tool_is_missing('wget')
 
-        upgrade_tmp_dir = os.path.join(ctl.USER_ZSTACK_HOME_DIR, 'upgrade', time.strftime('%Y-%m-%d-%H-%M-%S', time.gmtime()))
+        upgrade_tmp_dir = os.path.join(ctl.USER_ZSTACK_HOME_DIR, 'upgrade', time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime()))
         shell('mkdir -p %s' % upgrade_tmp_dir)
 
         property_file_backup_path = os.path.join(upgrade_tmp_dir, 'zstack.properties')
@@ -5858,7 +5858,7 @@ class UpgradeDbCmd(Command):
 
             info('start to backup the database ...')
 
-            db_backup_path = os.path.join(ctl.USER_ZSTACK_HOME_DIR, 'db_backup', time.strftime('%Y-%m-%d-%H-%M-%S', time.gmtime()), 'backup.sql')
+            db_backup_path = os.path.join(ctl.USER_ZSTACK_HOME_DIR, 'db_backup', time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime()), 'backup.sql')
             shell('mkdir -p %s' % os.path.dirname(db_backup_path))
             if db_password:
                 shell('mysqldump -u %s -p%s --host %s --port %s zstack > %s' % (db_user, db_password, db_hostname, db_port, db_backup_path))
@@ -5959,7 +5959,7 @@ class RollbackManagementNodeCmd(Command):
     def run(self, args):
         error_if_tool_is_missing('unzip')
 
-        rollback_tmp_dir = os.path.join(ctl.USER_ZSTACK_HOME_DIR, 'rollback', time.strftime('%Y-%m-%d-%H-%M-%S', time.gmtime()))
+        rollback_tmp_dir = os.path.join(ctl.USER_ZSTACK_HOME_DIR, 'rollback', time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime()))
         shell('mkdir -p %s' % rollback_tmp_dir)
         need_download = args.war_file.startswith('http')
 


### PR DESCRIPTION
`time.gmtime()`返回格林威治时间；
`time.localtime()`返回本地时间；
中国是东八区，因此后者比前者晚8小时。

之前是以`gmtime()`来命名文件夹，而通过`ls -l`获取到的文件夹创建时间却是`localtime()`的，
因此出现了不一致的情况。

解决办法将`gmtime()`替换为`localtime()`即可。