### PR TITLE
build zstack-ui.war on condition

### DIFF
--- a/zstackbuild/build.properties
+++ b/zstackbuild/build.properties
@@ -105,3 +105,4 @@ zstack.ui.source=${zstack_build_root}/zstack-ui
 build.zstack.ui.war.script=${zstackbuild.scripts}/build_zstack_ui_war.sh
 mevocoui2.build_version=${build_version}
 mevocouiserver.build_version=${build_version}
+build.zstack.ui.war=true

--- a/zstackbuild/build.xml
+++ b/zstackbuild/build.xml
@@ -178,6 +178,14 @@
         <echo message="successfully build zstack.war at ${war.file}" />
     </target>
 
+    <target name="build-zstack-ui-war-on-condition" if="${build.zstack.ui.war}">
+        <antcall target="build-zstack-ui-war" />
+    </target>
+
+    <target name="assemble-zstack-ui-war-on-condition" if="${build.zstack.ui.war}">
+        <antcall target="assemble-zstack-ui-war" />
+    </target>
+
     <target name="help">
         <echo message="usage: ant [build-war|package|all|build-vr] -Dzstack_build_root=YOUR_ZSTACK_PACKAGE_ROOT" />
         <echo message="[zstack_build_root] default path is /usr/local/zstack/root/, which is defined in build.properties. It should be the same parent folder for zstack-utility and zstack-woodpecker." />
@@ -213,7 +221,7 @@
                 <antcall target="build-apibinding"/>
             </sequential>
             <sequential>
-                <antcall target="build-zstack-ui-war"/>
+                <antcall target="build-zstack-ui-war-on-condition"/>
             </sequential>
             <sequential>
                 <antcall target="build-iscsi"/>
@@ -269,7 +277,7 @@
                 <antcall target="assemble-ctl"/>
             </sequential>
             <sequential>
-                <antcall target="assemble-zstack-ui-war"/>
+                <antcall target="assemble-zstack-ui-war-on-condition"/>
             </sequential>
             <sequential>
                 <antcall target="assemble-cli"/>


### PR DESCRIPTION
为ZStack的Build过程增加参数，使编译UI2.0成为可选，从而在UI2.0稳定之前减小对PR的影响。
- 编译带UI2.0的ZStack：
`ant -Dzstack_build_root=... -Dbuild_war_flag=premium all-in-one`
- 编译不带UI2.0的ZStack：
`ant -Dzstack_build_root=... -Dbuild_war_flag=premium -Dbuild.zstack.ui.war=false all-in-one`