### PR TITLE
<feature>[qga]: QGA Improvements IPv6 and Expanded OS Support

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_config.py
+++ b/kvmagent/kvmagent/plugins/vm_config.py
@@ -142,17 +142,20 @@ class VmConfigPlugin(kvmagent.KvmAgent):
     VM_QGA_PARAM_FILE = "/usr/local/zstack/zs-nics.json"
     VM_QGA_CONFIG_LINUX_CMD = "/usr/local/zstack/zs-tools/config_linux.py"
     VM_QGA_SET_HOSTNAME = "/usr/local/zstack/zs-tools/set_hostname_linux.py"
+    VM_QGA_SET_HOSTNAME_EL6 = "/usr/local/zstack/zs-tools/set_hostname_linux_el6.py"
     VM_CONFIG_SYNC_OS_VERSION_SUPPORT = {
-        VmQga.VM_OS_LINUX_CENTOS: ("7", "8"),
-        VmQga.VM_OS_LINUX_KYLIN: ("v10",),
+        VmQga.VM_OS_LINUX_CENTOS: ("6", "7", "8"),
+        VmQga.VM_OS_LINUX_KYLIN: ("4", "v10",),
         VmQga.VM_OS_LINUX_UOS: ("20",),
         VmQga.VM_OS_LINUX_OPEN_SUSE: ("12", "15",),
         VmQga.VM_OS_LINUX_SUSE_S: ("12", "15",),
         VmQga.VM_OS_LINUX_SUSE_D: ("12", "15",),
         VmQga.VM_OS_LINUX_ORACLE: ("7",),
         VmQga.VM_OS_LINUX_REDHAT: ("7",),
-        VmQga.VM_OS_LINUX_UBUNTU: ("18",),
-        VmQga.VM_OS_WINDOWS: ("10", "2012", "2012r2", "2016", "2019",)
+        VmQga.VM_OS_LINUX_UBUNTU: ("14", "16", "18",),
+        VmQga.VM_OS_LINUX_DEBIAN: ("9", "10",),
+        VmQga.VM_OS_LINUX_FEDORA: ("30", "31",),
+        VmQga.VM_OS_WINDOWS: ("10", "2012", "2012r2", "2016", "2019", "2008r2",)
     }
 
     @lock.lock('config_vm_by_qga')
@@ -212,7 +215,10 @@ class VmConfigPlugin(kvmagent.KvmAgent):
             return ret, msg
 
         # exec qga command
-        cmd_file = self.VM_QGA_SET_HOSTNAME
+        if qga.os_version == '6':
+            cmd_file = self.VM_QGA_SET_HOSTNAME_EL6
+        else:
+            cmd_file = self.VM_QGA_SET_HOSTNAME
         ret, msg = qga.guest_exec_python(cmd_file, [hostname, default_ip])
         if ret != 0:
             logger.debug("set vm hostname {} by qga failed: {}".format(vm_uuid, msg))


### PR DESCRIPTION
1.Add IPv6 vm config support
2.Read the IPv6 address from the VM.
3.Support additional guest operating systems, such as Centos6, Ubuntu16, debian, etc. 4.More bugfix

Resolves: ZSTAC-56243

Change-Id: I6868776c277a28fd38ad45eb9014d64a3931b6d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for CentOS version 6.x in service restart commands.
  - Added functionality to retrieve network information for Windows 2008 VMs.
  - Enhanced VM hostname setting to support different QGA OS versions.

- **Improvements**
  - Implemented a new decoding function to handle byte decoding with multiple fallback encodings.

- **Bug Fixes**
  - Updated VM configuration synchronization to include support for EL6 Linux distributions.
  - Refined methods in the `VmQga` class to utilize the new decoding function for improved data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->